### PR TITLE
Add sample Agent IDE extension

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -28,7 +28,8 @@ const ext = require('./lib/extensions');
 // 	ignore: ['**/out/**', '**/node_modules/**']
 // });
 const compilations = [
-	'extensions/configuration-editing/tsconfig.json',
+        'extensions/agent-ide/tsconfig.json',
+        'extensions/configuration-editing/tsconfig.json',
 	'extensions/css-language-features/client/tsconfig.json',
 	'extensions/css-language-features/server/tsconfig.json',
 	'extensions/debug-auto-launch/tsconfig.json',

--- a/extensions/agent-ide/README.md
+++ b/extensions/agent-ide/README.md
@@ -1,0 +1,17 @@
+# Agent IDE Extension
+
+This sample extension demonstrates a minimal agent-based development cycle.
+It defines six simple agents that run sequentially when the command
+`Agent IDE: Start Agent Development Cycle` is executed.
+
+Each agent currently displays an informational message. The agents are:
+
+1. **DesignAgent** – create the initial design
+2. **CodeAgent** – generate code
+3. **TestAgent** – run tests
+4. **ReviewAgent** – review the code
+5. **BuildAgent** – build artifacts
+6. **DeployAgent** – deploy the application
+
+This extension is intended as a proof of concept for using multiple agents
+to automate the development process.

--- a/extensions/agent-ide/package.json
+++ b/extensions/agent-ide/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "agent-ide",
+  "displayName": "Agent IDE",
+  "description": "Demonstration extension with agent-based development cycle",
+  "version": "0.0.1",
+  "publisher": "vscode",
+  "engines": {
+    "vscode": "^1.70.0"
+  },
+  "activationEvents": [
+    "onCommand:agentIDE.startDevelopmentCycle"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "agentIDE.startDevelopmentCycle",
+        "title": "Start Agent Development Cycle"
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "gulp compile-extension:agent-ide",
+    "watch": "gulp watch-extension:agent-ide"
+  }
+}

--- a/extensions/agent-ide/package.nls.json
+++ b/extensions/agent-ide/package.nls.json
@@ -1,0 +1,4 @@
+{
+  "displayName": "Agent IDE",
+  "description": "Demonstration extension that uses six agents to automate the development cycle."
+}

--- a/extensions/agent-ide/src/extension.ts
+++ b/extensions/agent-ide/src/extension.ts
@@ -1,0 +1,76 @@
+/*---------------------------------------------------------
+ * Agent IDE Extension - Demonstrates a simple agent based
+ * development cycle consisting of six agents.
+ *--------------------------------------------------------*/
+import * as vscode from 'vscode';
+
+interface Agent {
+    name: string;
+    run(): Promise<void>;
+}
+
+class DesignAgent implements Agent {
+    name = 'DesignAgent';
+    async run(): Promise<void> {
+        vscode.window.showInformationMessage('DesignAgent: generating design...');
+    }
+}
+
+class CodeAgent implements Agent {
+    name = 'CodeAgent';
+    async run(): Promise<void> {
+        vscode.window.showInformationMessage('CodeAgent: writing code...');
+    }
+}
+
+class TestAgent implements Agent {
+    name = 'TestAgent';
+    async run(): Promise<void> {
+        vscode.window.showInformationMessage('TestAgent: running tests...');
+    }
+}
+
+class ReviewAgent implements Agent {
+    name = 'ReviewAgent';
+    async run(): Promise<void> {
+        vscode.window.showInformationMessage('ReviewAgent: reviewing code...');
+    }
+}
+
+class BuildAgent implements Agent {
+    name = 'BuildAgent';
+    async run(): Promise<void> {
+        vscode.window.showInformationMessage('BuildAgent: building artifacts...');
+    }
+}
+
+class DeployAgent implements Agent {
+    name = 'DeployAgent';
+    async run(): Promise<void> {
+        vscode.window.showInformationMessage('DeployAgent: deploying application...');
+    }
+}
+
+const agents: Agent[] = [
+    new DesignAgent(),
+    new CodeAgent(),
+    new TestAgent(),
+    new ReviewAgent(),
+    new BuildAgent(),
+    new DeployAgent()
+];
+
+export function activate(context: vscode.ExtensionContext): void {
+    const startCommand = vscode.commands.registerCommand('agentIDE.startDevelopmentCycle', async () => {
+        for (const agent of agents) {
+            await agent.run();
+        }
+        vscode.window.showInformationMessage('Agent development cycle completed.');
+    });
+
+    context.subscriptions.push(startCommand);
+}
+
+export function deactivate(): void {
+    // Clean up resources if necessary
+}

--- a/extensions/agent-ide/tsconfig.json
+++ b/extensions/agent-ide/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./out"
+    },
+    "include": [
+        "src/**/*",
+        "../../src/vscode-dts/vscode.d.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- add `agent-ide` sample extension with six demo agents
- include new extension in build compilation list

## Testing
- `npx gulp compile-extension:agent-ide` *(fails: EHOSTUNREACH)*