### PR TITLE
Add AOSDev extension skeleton

### DIFF
--- a/build/gulpfile.extensions.js
+++ b/build/gulpfile.extensions.js
@@ -28,6 +28,7 @@ const ext = require('./lib/extensions');
 // 	ignore: ['**/out/**', '**/node_modules/**']
 // });
 const compilations = [
+        'extensions/aos-dev/tsconfig.json',
         'extensions/agent-ide/tsconfig.json',
         'extensions/configuration-editing/tsconfig.json',
 	'extensions/css-language-features/client/tsconfig.json',

--- a/extensions/aos-dev/README.md
+++ b/extensions/aos-dev/README.md
@@ -1,0 +1,12 @@
+# AOSDev Extension
+
+The **AOSDev** extension integrates the AOS agentic development workflow directly into the AOSCode editor. It provides a starting point for creating and managing agents and workflows without leaving the IDE.
+
+This initial version exposes a command to open the **AOSDev Panel** and a simple command for creating an agent. The panel is implemented as a webview and can be extended to host a full React/ReactFlow application for visual workflow editing.
+
+## Commands
+
+- **AOSDev: Open Panel** – Opens the AOSDev management panel.
+- **AOSDev: Create Agent** – Prompts for a name and creates a placeholder agent entry.
+
+This extension is a foundation for a richer agentic development experience.

--- a/extensions/aos-dev/package.json
+++ b/extensions/aos-dev/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "aos-dev",
+  "displayName": "AOSDev Tools",
+  "description": "Agentic development workflow integration for AOSCode",
+  "version": "0.0.1",
+  "publisher": "aos",
+  "engines": {
+    "vscode": "^1.70.0"
+  },
+  "activationEvents": [
+    "onCommand:aosDev.openPanel",
+    "onCommand:aosDev.createAgent"
+  ],
+  "main": "./out/extension",
+  "contributes": {
+    "commands": [
+      {
+        "command": "aosDev.openPanel",
+        "title": "AOSDev: Open Panel"
+      },
+      {
+        "command": "aosDev.createAgent",
+        "title": "AOSDev: Create Agent"
+      }
+    ]
+  },
+  "scripts": {
+    "compile": "gulp compile-extension:aos-dev",
+    "watch": "gulp watch-extension:aos-dev"
+  }
+}

--- a/extensions/aos-dev/src/extension.ts
+++ b/extensions/aos-dev/src/extension.ts
@@ -1,0 +1,24 @@
+/*---------------------------------------------------------
+ * AOSDev Extension - Provides agent and workflow utilities
+ *--------------------------------------------------------*/
+import * as vscode from 'vscode';
+import { AOSDevPanel } from './panel';
+
+export function activate(context: vscode.ExtensionContext): void {
+    const openCommand = vscode.commands.registerCommand('aosDev.openPanel', () => {
+        AOSDevPanel.createOrShow(context.extensionUri);
+    });
+
+    const createAgentCommand = vscode.commands.registerCommand('aosDev.createAgent', async () => {
+        const name = await vscode.window.showInputBox({ prompt: 'Enter agent name' });
+        if (name) {
+            vscode.window.showInformationMessage(`Creating agent "${name}" (placeholder).`);
+        }
+    });
+
+    context.subscriptions.push(openCommand, createAgentCommand);
+}
+
+export function deactivate(): void {
+    // Cleanup if needed
+}

--- a/extensions/aos-dev/src/panel.ts
+++ b/extensions/aos-dev/src/panel.ts
@@ -1,0 +1,77 @@
+import * as vscode from 'vscode';
+
+export class AOSDevPanel {
+    public static currentPanel: AOSDevPanel | undefined;
+    private disposables: vscode.Disposable[] = [];
+
+    private constructor(
+        private readonly panel: vscode.WebviewPanel
+    ) {
+        this.initialize();
+    }
+
+    public static createOrShow(_extensionUri: vscode.Uri): void {
+        const column = vscode.ViewColumn.Beside;
+        if (AOSDevPanel.currentPanel) {
+            AOSDevPanel.currentPanel.panel.reveal(column);
+            return;
+        }
+        const panel = vscode.window.createWebviewPanel(
+            'aosDevPanel',
+            'AOSDev Panel',
+            column,
+            { enableScripts: true }
+        );
+        AOSDevPanel.currentPanel = new AOSDevPanel(panel);
+    }
+
+    private initialize(): void {
+        this.panel.webview.html = this.getHtml();
+        this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+    }
+
+    private getHtml(): string {
+        const nonce = getNonce();
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src https: data:; script-src 'nonce-${nonce}' https:; style-src 'nonce-${nonce}' https:;">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AOSDev Panel</title>
+    <style nonce="${nonce}">
+        body { font-family: sans-serif; padding: 10px; }
+        #root { height: 400px; border: 1px solid #ccc; }
+    </style>
+</head>
+<body>
+    <h2>AOSDev Panel</h2>
+    <div id="root">Workflow editor placeholder</div>
+    <script nonce="${nonce}">
+        // Placeholder for React/ReactFlow app
+        console.log('AOSDev panel loaded');
+    </script>
+</body>
+</html>`;
+    }
+
+    public dispose(): void {
+        AOSDevPanel.currentPanel = undefined;
+        this.panel.dispose();
+        while (this.disposables.length) {
+            const d = this.disposables.pop();
+            if (d) {
+                d.dispose();
+            }
+        }
+    }
+}
+
+function getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}

--- a/extensions/aos-dev/tsconfig.json
+++ b/extensions/aos-dev/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../tsconfig.base.json",
+    "compilerOptions": {
+        "outDir": "./out"
+    },
+    "include": [
+        "src/**/*",
+        "../../src/vscode-dts/vscode.d.ts"
+    ]
+}


### PR DESCRIPTION
## Summary
- add new `aos-dev` extension with panel and agent creation command
- register extension build in `gulpfile.extensions.js`

## Testing
- `npx tsc -p extensions/aos-dev/tsconfig.json --noEmit`
- `node build/hygiene.js extensions/aos-dev/src/extensions extensions/aos-dev/package.json` *(fails: Cannot find module 'gulp-filter')*