### PR TITLE
Add agent selection command to AOSDev extension

### DIFF
--- a/extensions/aos-dev/README.md
+++ b/extensions/aos-dev/README.md
@@ -2,11 +2,12 @@
 
 The **AOSDev** extension integrates the AOS agentic development workflow directly into the AOSCode editor. It provides a starting point for creating and managing agents and workflows without leaving the IDE.
 
-This initial version exposes a command to open the **AOSDev Panel** and a simple command for creating an agent. The panel is implemented as a webview and can be extended to host a full React/ReactFlow application for visual workflow editing.
+This initial version exposes commands to open the **AOSDev Panel**, create a placeholder agent, and select which of the built-in AOSCode agents should participate in a coding task. The panel is implemented as a webview and can be extended to host a full React/ReactFlow application for visual workflow editing.
 
 ## Commands
 
 - **AOSDev: Open Panel** – Opens the AOSDev management panel.
 - **AOSDev: Create Agent** – Prompts for a name and creates a placeholder agent entry.
+- **AOSDev: Select Agents** – Choose from a list of predefined AOSCode agents. Supports multi-select to assign multiple agents to a task.
 
 This extension is a foundation for a richer agentic development experience.

--- a/extensions/aos-dev/package.json
+++ b/extensions/aos-dev/package.json
@@ -9,7 +9,8 @@
   },
   "activationEvents": [
     "onCommand:aosDev.openPanel",
-    "onCommand:aosDev.createAgent"
+    "onCommand:aosDev.createAgent",
+    "onCommand:aosDev.selectAgents"
   ],
   "main": "./out/extension",
   "contributes": {
@@ -21,6 +22,10 @@
       {
         "command": "aosDev.createAgent",
         "title": "AOSDev: Create Agent"
+      },
+      {
+        "command": "aosDev.selectAgents",
+        "title": "AOSDev: Select Agents"
       }
     ]
   },

--- a/extensions/aos-dev/src/extension.ts
+++ b/extensions/aos-dev/src/extension.ts
@@ -16,7 +16,39 @@ export function activate(context: vscode.ExtensionContext): void {
         }
     });
 
-    context.subscriptions.push(openCommand, createAgentCommand);
+    const selectAgentsCommand = vscode.commands.registerCommand('aosDev.selectAgents', async () => {
+        const agents = [
+            'CEO Agent',
+            'COO Agent',
+            'CTO Agent',
+            'CFO Agent',
+            'CMO Agent',
+            'TechWorker',
+            'SupportBot',
+            'EscalationBot',
+            'RefundAgent',
+            'Compliance',
+            'SecurityAuditor',
+            'ProjectManager',
+            'TaskRouter',
+            'Development Team',
+            'Design Team',
+            'Quality Assurance'
+        ];
+
+        const picks = await vscode.window.showQuickPick(agents, {
+            canPickMany: true,
+            placeHolder: 'Select agents for this coding task'
+        });
+
+        if (picks && picks.length > 0) {
+            vscode.window.showInformationMessage(`Assigned agents: ${picks.join(', ')}`);
+        } else {
+            vscode.window.showInformationMessage('No agents selected');
+        }
+    });
+
+    context.subscriptions.push(openCommand, createAgentCommand, selectAgentsCommand);
 }
 
 export function deactivate(): void {


### PR DESCRIPTION
## Summary
- add a `Select Agents` command that lets users pick multiple agents from a dropdown
- register the command in the extension manifest
- document the new command in the AOSDev README

## Testing
- `npm test` *(passes: command shows no tests)*
- `npm run compile` in `extensions/aos-dev` *(fails: `gulp` not found)*