### PR TITLE
Add Huro AI Agent Marketplace docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ AOSCode can run a variety of open-source models locally via [Ollama](https://oll
  * **huroai/phoenixcoder** ([HuggingFace](https://huggingface.co/huro-ai/phoenixcoder), [Ollama](https://ollama.com/huroai/phoenixcoder))
 * **AOSM (custom)** – see [AOSM model training guide](docs/AOSM_model_training.md) for instructions
 
+## Agent Marketplace
+
+Browse the [Huro AI Agent Marketplace](docs/agent_marketplace.md) to discover built‑in
+agents. Each entry lists the agent's purpose and a themed logo idea so you can
+customize visuals for your workflow.
+
 ## Development Container
 
   AOSCode includes a Dev Container configuration. Docker or Codespaces should be provisioned with at least **4 cores and 6&nbsp;GB of RAM (8&nbsp;GB recommended)** to build the project. See [.devcontainer/README.md](.devcontainer/README.md) for details.

--- a/docs/agent_marketplace.md
+++ b/docs/agent_marketplace.md
@@ -1,0 +1,24 @@
+# Huro AI Agent Marketplace
+
+The **Agent Marketplace** in AOSCode provides a library of installable and editable agents. Each agent represents a specialized role within the Huro AI ecosystem. Use this table as a reference when designing icons and promotional materials.
+
+| Agent Name | Role Description | Themed Logo Idea |
+|------------|-----------------|------------------|
+| CEO Agent | Executive decision-making & oversight | Executive suit icon in deep purple |
+| COO Agent | Operational management and efficiency | Gears and flowchart in green shades |
+| CTO Agent | Technology strategy and innovation | Circuit board and light bulb in blue |
+| CFO Agent | Financial planning and compliance | Dollar sign and ledger in gold |
+| CMO Agent | Marketing strategy and consumer engagement | Megaphone and analytics in orange |
+| TechWorker | Technical task execution & diagnostics | Screwdriver and wrench in teal |
+| SupportBot | Customer support and communication | Chat bubble and headset in sky blue |
+| EscalationBot | Handling escalations and human intervention | Alarm bell icon in red |
+| RefundAgent | Transaction management (refund processing) | Credit card with reverse arrow green |
+| Compliance | Policy enforcement and compliance checks | Shield and checkmark in silver/grey |
+| SecurityAuditor | Security assessments and vulnerability scanning | Lock and scanner icon in dark red |
+| ProjectManager | Project timelines and resource management | Clipboard and timeline in navy blue |
+| TaskRouter | Task distribution and workload management | Route arrows icon in dark purple |
+| Development Team | Software development and maintenance | Code brackets in neon blue |
+| Design Team | UI/UX design and prototyping | Paintbrush and palette in coral |
+| Quality Assurance | Testing and validation of systems/software | Magnifying glass & checkmark in lime |
+
+Future versions of AOSCode may surface these agents directly within the IDE, allowing you to mix and match them for custom workflows.

--- a/extensions/aos-dev/README.md
+++ b/extensions/aos-dev/README.md
@@ -2,7 +2,7 @@
 
 The **AOSDev** extension integrates the AOS agentic development workflow directly into the AOSCode editor. It provides a starting point for creating and managing agents and workflows without leaving the IDE.
 
-This initial version exposes commands to open the **AOSDev Panel**, create a placeholder agent, and select which of the built-in AOSCode agents should participate in a coding task. The panel is implemented as a webview and can be extended to host a full React/ReactFlow application for visual workflow editing.
+This extension exposes commands to open the **AOSDev Panel**, create a placeholder agent, and select which of the built-in AOSCode agents should participate in a coding task. Available agents are defined in `marketplace.json` which represents the AOSCode Agent Marketplace. The panel is implemented as a webview and can be extended to host a full React/ReactFlow application for visual workflow editing.
 
 ## Commands
 

--- a/extensions/aos-dev/marketplace.json
+++ b/extensions/aos-dev/marketplace.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "CEO Agent",
+    "role": "Executive decision-making & oversight",
+    "logo": "Executive suit icon in deep purple"
+  },
+  {
+    "name": "COO Agent",
+    "role": "Operational management and efficiency",
+    "logo": "Gears and flowchart in green shades"
+  },
+  {
+    "name": "CTO Agent",
+    "role": "Technology strategy and innovation",
+    "logo": "Circuit board and light bulb in blue"
+  },
+  {
+    "name": "CFO Agent",
+    "role": "Financial planning and compliance",
+    "logo": "Dollar sign and ledger in gold"
+  },
+  {
+    "name": "CMO Agent",
+    "role": "Marketing strategy and consumer engagement",
+    "logo": "Megaphone and analytics in orange"
+  },
+  {
+    "name": "TechWorker",
+    "role": "Technical task execution & diagnostics",
+    "logo": "Screwdriver and wrench in teal"
+  },
+  {
+    "name": "SupportBot",
+    "role": "Customer support and communication",
+    "logo": "Chat bubble and headset in sky blue"
+  },
+  {
+    "name": "EscalationBot",
+    "role": "Handling escalations and human intervention",
+    "logo": "Alarm bell icon in red"
+  },
+  {
+    "name": "RefundAgent",
+    "role": "Transaction management (refund processing)",
+    "logo": "Credit card with reverse arrow green"
+  },
+  {
+    "name": "Compliance",
+    "role": "Policy enforcement and compliance checks",
+    "logo": "Shield and checkmark in silver/grey"
+  },
+  {
+    "name": "SecurityAuditor",
+    "role": "Security assessments and vulnerability scanning",
+    "logo": "Lock and scanner icon in dark red"
+  },
+  {
+    "name": "ProjectManager",
+    "role": "Project timelines and resource management",
+    "logo": "Clipboard and timeline in navy blue"
+  },
+  {
+    "name": "TaskRouter",
+    "role": "Task distribution and workload management",
+    "logo": "Route arrows icon in dark purple"
+  },
+  {
+    "name": "Development Team",
+    "role": "Software development and maintenance",
+    "logo": "Code brackets in neon blue"
+  },
+  {
+    "name": "Design Team",
+    "role": "UI/UX design and prototyping",
+    "logo": "Paintbrush and palette in coral"
+  },
+  {
+    "name": "Quality Assurance",
+    "role": "Testing and validation of systems/software",
+    "logo": "Magnifying glass & checkmark in lime"
+  }
+]

--- a/extensions/aos-dev/src/extension.ts
+++ b/extensions/aos-dev/src/extension.ts
@@ -3,6 +3,8 @@
  *--------------------------------------------------------*/
 import * as vscode from 'vscode';
 import { AOSDevPanel } from './panel';
+import * as fs from 'fs';
+import * as path from 'path';
 
 export function activate(context: vscode.ExtensionContext): void {
     const openCommand = vscode.commands.registerCommand('aosDev.openPanel', () => {
@@ -17,24 +19,19 @@ export function activate(context: vscode.ExtensionContext): void {
     });
 
     const selectAgentsCommand = vscode.commands.registerCommand('aosDev.selectAgents', async () => {
-        const agents = [
-            'CEO Agent',
-            'COO Agent',
-            'CTO Agent',
-            'CFO Agent',
-            'CMO Agent',
-            'TechWorker',
-            'SupportBot',
-            'EscalationBot',
-            'RefundAgent',
-            'Compliance',
-            'SecurityAuditor',
-            'ProjectManager',
-            'TaskRouter',
-            'Development Team',
-            'Design Team',
-            'Quality Assurance'
-        ];
+        // Load agent list from marketplace.json packaged with the extension
+        const marketplacePath = path.join(context.extensionPath, 'marketplace.json');
+        let agents: string[] = [];
+        try {
+            const raw = fs.readFileSync(marketplacePath, 'utf8');
+            const data = JSON.parse(raw) as Array<{ name: string }>;
+            agents = data.map(a => a.name);
+        } catch (err) {
+            console.error('Failed to load marketplace.json', err);
+        }
+        if (agents.length === 0) {
+            agents = ['CEO Agent'];
+        }
 
         const picks = await vscode.window.showQuickPick(agents, {
             canPickMany: true,


### PR DESCRIPTION
## Summary
- document available agents in `docs/agent_marketplace.md`
- link the new Agent Marketplace from README
- load agent names from `marketplace.json` in the AOSDev extension
- update AOSDev README to mention marketplace

## Testing
- `npm test`