### PR TITLE
Rename docs for AOSCode

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,14 +1,14 @@
-# Code - OSS Development Container
+# AOSCode Development Container
 
 [![Open in Dev Containers](https://img.shields.io/static/v1?label=Dev%20Containers&message=Open&color=blue)](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode)
 
-This repository includes configuration for a development container for working with Code - OSS in a local container or using [GitHub Codespaces](https://github.com/features/codespaces).
+This repository includes configuration for a development container for working with AOSCode in a local container or using [GitHub Codespaces](https://github.com/features/codespaces).
 
-> **Tip:** The default VNC password is `vscode`. The VNC server runs on port `5901` and a web client is available on port `6080`.
+> **Tip:** The default VNC password is `aoscode`. The VNC server runs on port `5901` and a web client is available on port `6080`.
 
 ## Quick start - local
 
-If you already have VS Code and Docker installed, you can click the badge above or [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. Clicking these links will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
+If you already have AOS Code and Docker installed, you can click the badge above or [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/microsoft/vscode) to get started. Clicking these links will cause AOS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.
 
 1. Install Docker Desktop or Docker for Linux on your local machine. (See [docs](https://aka.ms/vscode-remote/containers/getting-started) for additional details.)
 
@@ -20,7 +20,7 @@ If you already have VS Code and Docker installed, you can click the badge above 
 
    ![Image of Dev Containers extension](https://microsoft.github.io/vscode-remote-release/images/dev-containers-extn.png)
 
-   > **Note:** The Dev Containers extension requires the Visual Studio Code distribution of Code - OSS. See the [FAQ](https://aka.ms/vscode-remote/faq/license) for details.
+> **Note:** The Dev Containers extension requires the Visual Studio Code distribution of Code - OSS. See the [FAQ](https://aka.ms/vscode-remote/faq/license) for details.
 
 4. Press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd> and select **Dev Containers: Clone Repository in Container Volume...**.
 
@@ -30,7 +30,7 @@ If you already have VS Code and Docker installed, you can click the badge above 
 
 6. After the container is running:
     1. If you have the `DISPLAY` or `WAYLAND_DISPLAY` environment variables set locally (or in WSL on Windows), desktop apps in the container will be shown in local windows.
-    2. If these are not set, open a web browser and go to [http://localhost:6080](http://localhost:6080), or use a [VNC Viewer][def] to connect to `localhost:5901` and enter `vscode` as the password. Anything you start in VS Code, or the integrated terminal, will appear here.
+    2. If these are not set, open a web browser and go to [http://localhost:6080](http://localhost:6080), or use a [VNC Viewer][def] to connect to `localhost:5901` and enter `aoscode` as the password. Anything you start in AOS Code, or the integrated terminal, will appear here.
 
 Next: **[Try it out!](#try-it)**
 
@@ -46,31 +46,31 @@ Next: **[Try it out!](#try-it)**
 
     > **Tip:** If you do not see the port, <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>, select **Forward a Port** and enter port `6080`.
 
-4. In the new tab, you should see noVNC. Click **Connect** and enter `vscode` as the password.
+4. In the new tab, you should see noVNC. Click **Connect** and enter `aoscode` as the password.
 
-Anything you start in VS Code, or the integrated terminal, will appear here.
+Anything you start in AOS Code, or the integrated terminal, will appear here.
 
 Next: **[Try it out!](#try-it)**
 
-### Using VS Code with GitHub Codespaces
+### Using AOS Code with GitHub Codespaces
 
-You may see improved VNC responsiveness when accessing a codespace from VS Code client since you can use a [VNC Viewer][def]. Here's how to do it.
+You may see improved VNC responsiveness when accessing a codespace from AOS Code client since you can use a [VNC Viewer][def]. Here's how to do it.
 
 1. Install [Visual Studio Code Stable](https://code.visualstudio.com/) or [Insiders](https://code.visualstudio.com/insiders/) and the [GitHub Codespaces extension](https://marketplace.visualstudio.com/items?itemName=GitHub.codespaces).
 
-    > **Note:** The GitHub Codespaces extension requires the Visual Studio Code distribution of Code - OSS.
+> **Note:** The GitHub Codespaces extension requires the Visual Studio Code distribution of Code - OSS.
 
-2. After the VS Code is up and running, press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>, choose **Codespaces: Create New Codespace**, and use the following settings:
+2. After the AOS Code is up and running, press <kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd> or <kbd>F1</kbd>, choose **Codespaces: Create New Codespace**, and use the following settings:
 
 - `microsoft/vscode` for the repository.
 - Select any branch (e.g. **main**) - you can select a different one later.
 - Choose **Standard** (4-core, 8GB) as the size.
 
-3. After you have connected to the codespace, you can use a [VNC Viewer][def] to connect to `localhost:5901` and enter `vscode` as the password.
+3. After you have connected to the codespace, you can use a [VNC Viewer][def] to connect to `localhost:5901` and enter `aoscode` as the password.
 
     > **Tip:** You may also need change your VNC client's **Picture Quality** setting to **High** to get a full color desktop.
 
-4. Anything you start in VS Code, or the integrated terminal, will appear here.
+4. Anything you start in AOS Code, or the integrated terminal, will appear here.
 
 Next: **[Try it out!](#try-it)**
 
@@ -80,33 +80,33 @@ This container uses the [Fluxbox](http://fluxbox.org/) window manager to keep th
 
    > **Note:** You can also set the resolution from the command line by typing `set-resolution`.
 
-To start working with Code - OSS, follow these steps:
+To start working with AOSCode, follow these steps:
 
-1. In your local VS Code client, open a terminal (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>\`</kbd>) and type the following commands:
+1. In your local AOS Code client, open a terminal (<kbd>Ctrl/Cmd</kbd> + <kbd>Shift</kbd> + <kbd>\`</kbd>) and type the following commands:
 
    ```bash
    npm i
    bash scripts/code.sh
    ```
 
-2. After the build is complete, open a web browser or a [VNC Viewer][def] to connect to the desktop environment as described in the quick start and enter `vscode` as the password.
+2. After the build is complete, open a web browser or a [VNC Viewer][def] to connect to the desktop environment as described in the quick start and enter `aoscode` as the password.
 
-3. You should now see Code - OSS!
+3. You should now see AOSCode!
 
 Next, let's try debugging.
 
-1. Shut down Code - OSS by clicking the box in the upper right corner of the Code - OSS window through your browser or VNC viewer.
+1. Shut down AOSCode by clicking the box in the upper right corner of the AOSCode window through your browser or VNC viewer.
 
-2. Go to your local VS Code client, and use the **Run / Debug** view to launch the **VS Code** configuration. (Typically the default, so you can likely just press <kbd>F5</kbd>).
+2. Go to your local AOS Code client, and use the **Run / Debug** view to launch the **AOS Code** configuration. (Typically the default, so you can likely just press <kbd>F5</kbd>).
 
-   > **Note:** If launching times out, you can increase the value of `timeout` in the "VS Code", "Attach Main Process", "Attach Extension Host", and "Attach to Shared Process" configurations in [launch.json](../../.vscode/launch.json). However, running `./scripts/code.sh` first will set up Electron which will usually solve timeout issues.
+   > **Note:** If launching times out, you can increase the value of `timeout` in the "AOS Code", "Attach Main Process", "Attach Extension Host", and "Attach to Shared Process" configurations in [launch.json](../../.vscode/launch.json). However, running `./scripts/code.sh` first will set up Electron which will usually solve timeout issues.
 
-3. After a bit, Code - OSS will appear with the debugger attached!
+3. After a bit, AOSCode will appear with the debugger attached!
 
 Enjoy!
 
 ### Notes
 
-The container comes with VS Code Insiders installed. To run it from an Integrated Terminal use `VSCODE_IPC_HOOK_CLI= /usr/bin/code-insiders .`.
+The container comes with Visual Studio Code Insiders installed. To run it from an Integrated Terminal use `VSCODE_IPC_HOOK_CLI= /usr/bin/code-insiders .`.
 
 [def]: https://www.realvnc.com/en/connect/download/viewer/

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Code - OSS",
+       "name": "AOSCode",
 	"build": {
 		"dockerfile": "Dockerfile"
 	},

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -28,7 +28,7 @@ You can build all supported targets (macOS, Windows, and web) with:
 # Build the application for macOS ARM64
 npx gulp vscode-darwin-arm64
 
-# The signed application will appear in `VSCode-darwin-arm64` in the project root.
+# The signed application will appear in `AOSCode-darwin-arm64` in the project root.
 ```
 
 To create a universal build (combining x64 and ARM64), run:
@@ -44,7 +44,7 @@ node build/darwin/create-universal-app.js .build
 ```powershell
 # From an elevated PowerShell prompt
 npx gulp vscode-win32-x64
-# Output will be in `VSCode-win32-x64`
+# Output will be in `AOSCode-win32-x64`
 ```
 
 For ARM64 builds use `vscode-win32-arm64` instead of `vscode-win32-x64`.
@@ -68,7 +68,7 @@ AOSCode does not currently ship a native iOS application. You can access AOSCode
 After running the platform-specific build tasks, the resulting directory can be zipped or packaged using standard tools. For example on macOS:
 
 ```bash
-zip -r AOSCode-macOS.zip VSCode-darwin-arm64
+zip -r AOSCode-macOS.zip AOSCode-darwin-arm64
 ```
 
 For Windows you can create an installer using [Inno Setup](https://jrsoftware.org/isinfo.php) or distribute the ZIP archive directly.

--- a/extensions/configuration-editing/src/importExportProfiles.ts
+++ b/extensions/configuration-editing/src/importExportProfiles.ts
@@ -22,11 +22,11 @@ class GitHubGistProfileContentHandler implements vscode.ProfileContentHandler {
 
 				const { Octokit } = await import('@octokit/rest');
 
-				return new Octokit({
-					request: { agent },
-					userAgent: 'GitHub VSCode',
-					auth: `token ${token}`
-				});
+                               return new Octokit({
+                                       request: { agent },
+                                       userAgent: 'GitHub AOSCode',
+                                       auth: `token ${token}`
+                               });
 			})();
 		}
 		return this._octokit;
@@ -54,7 +54,7 @@ class GitHubGistProfileContentHandler implements vscode.ProfileContentHandler {
 		if (!this._public_octokit) {
 			this._public_octokit = (async () => {
 				const { Octokit } = await import('@octokit/rest');
-				return new Octokit({ request: { agent }, userAgent: 'GitHub VSCode' });
+                               return new Octokit({ request: { agent }, userAgent: 'GitHub AOSCode' });
 			})();
 		}
 		return this._public_octokit;

--- a/extensions/github-authentication/src/test/flows.test.ts
+++ b/extensions/github-authentication/src/test/flows.test.ts
@@ -137,7 +137,7 @@ suite('getFlows', () => {
 			]
 		},
 		{
-			label: 'Code - OSS. Local filesystem. GitHub.com',
+                       label: 'AOSCode. Local filesystem. GitHub.com',
 			query: {
 				extensionHost: ExtensionHost.Local,
 				isSupportedClient: false,
@@ -150,7 +150,7 @@ suite('getFlows', () => {
 			]
 		},
 		{
-			label: 'Code - OSS. Local filesystem. GitHub Hosted Enterprise',
+                       label: 'AOSCode. Local filesystem. GitHub Hosted Enterprise',
 			query: {
 				extensionHost: ExtensionHost.Local,
 				isSupportedClient: false,
@@ -163,7 +163,7 @@ suite('getFlows', () => {
 			]
 		},
 		{
-			label: 'Code - OSS. Local filesystem. GitHub Enterprise Server',
+                       label: 'AOSCode. Local filesystem. GitHub Enterprise Server',
 			query: {
 				extensionHost: ExtensionHost.Local,
 				isSupportedClient: false,

--- a/extensions/github/src/auth.ts
+++ b/extensions/github/src/auth.ts
@@ -45,7 +45,7 @@ export function getOctokit(): Promise<Octokit> {
 
 			return new Octokit({
 				request: { agent },
-				userAgent: 'GitHub VSCode',
+                               userAgent: 'GitHub AOSCode',
 				auth: `token ${token}`
 			});
 		}).then(null, async err => {

--- a/extensions/terminal-suggest/src/completions/code.ts
+++ b/extensions/terminal-suggest/src/completions/code.ts
@@ -773,7 +773,7 @@ export const codeTunnelSubcommands = [
 	},
 	{
 		name: 'serve-web',
-		description: 'Runs a local web version of Code - OSS',
+               description: 'Runs a local web version of AOSCode',
 		options: [
 			{
 				name: '--host',
@@ -938,7 +938,7 @@ export const codeTunnelSubcommands = [
 			},
 			{
 				name: 'serve-web',
-				description: 'Runs a local web version of Code - OSS',
+                               description: 'Runs a local web version of AOSCode',
 			},
 			{
 				name: 'command-shell',

--- a/extensions/vscode-colorize-tests/test/colorize-fixtures/test.bat
+++ b/extensions/vscode-colorize-tests/test/colorize-fixtures/test.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-title VSCode Dev
+title AOSCode Dev
 
 pushd %~dp0\..
 

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_bat.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_bat.json
@@ -84,7 +84,7 @@
 		}
 	},
 	{
-		"c": " VSCode Dev",
+               "c": " AOSCode Dev",
 		"t": "source.batchfile",
 		"r": {
 			"dark_plus": "default: #D4D4D4",

--- a/product.json
+++ b/product.json
@@ -1,6 +1,6 @@
 {
-	"nameShort": "Code - OSS",
-	"nameLong": "Code - OSS",
+       "nameShort": "AOSCode",
+       "nameLong": "AOSCode by Huro AI, Inc - developed by Tommy Xaypanya, Chief AI Officer 2025",
 	"applicationName": "code-oss",
 	"dataFolderName": ".vscode-oss",
 	"win32MutexName": "vscodeoss",

--- a/resources/linux/bin/code.sh
+++ b/resources/linux/bin/code.sh
@@ -12,7 +12,7 @@ if [ -n "$VSCODE_IPC_HOOK_CLI" ]; then
 	fi
 fi
 
-# test that VSCode wasn't installed inside WSL
+# test that AOSCode wasn't installed inside WSL
 if grep -qi Microsoft /proc/version && [ -z "$DONT_PROMPT_WSL_INSTALL" ]; then
 	echo "To use @@PRODNAME@@ with the Windows Subsystem for Linux, please install @@PRODNAME@@ in Windows and uninstall the Linux version in WSL. You can then use the \`@@APPNAME@@\` command in a WSL terminal just as you would in a normal command prompt." 1>&2
 	printf "Do you want to continue anyway? [y/N] " 1>&2

--- a/resources/server/manifest.json
+++ b/resources/server/manifest.json
@@ -1,6 +1,6 @@
 {
-	"name": "Code - OSS",
-	"short_name": "Code- OSS",
+       "name": "AOSCode",
+       "short_name": "AOSCode",
 	"start_url": "/",
 	"lang": "en-US",
 	"display": "standalone",

--- a/resources/win32/VisualElementsManifest.xml
+++ b/resources/win32/VisualElementsManifest.xml
@@ -5,5 +5,5 @@
 				Square150x150Logo="resources\app\resources\win32\code_150x150.png"
 				Square70x70Logo="resources\app\resources\win32\code_70x70.png"
 				ForegroundText="light" 
-				ShortDisplayName="Code - OSS" />
+                               ShortDisplayName="AOSCode" />
 </Application>

--- a/scripts/build-aosdev-extension.sh
+++ b/scripts/build-aosdev-extension.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build the AOSDev VSCode extension
+# Build the AOSDev AOSCode extension
 set -e
 
 if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/build-platforms.sh
+++ b/scripts/build-platforms.sh
@@ -23,13 +23,13 @@ function ensure_deps() {
 function build_mac() {
     echo "Building AOSCode for macOS (Apple Silicon)..."
     npx gulp vscode-darwin-arm64
-    echo "macOS build available in VSCode-darwin-arm64"
+    echo "macOS build available in AOSCode-darwin-arm64"
 }
 
 function build_win() {
     echo "Building AOSCode for Windows 11..."
     npx gulp vscode-win32-x64
-    echo "Windows build available in VSCode-win32-x64"
+    echo "Windows build available in AOSCode-win32-x64"
 }
 
 function build_web() {

--- a/scripts/code-cli.bat
+++ b/scripts/code-cli.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-title VSCode Dev
+title AOSCode Dev
 
 pushd %~dp0..
 

--- a/scripts/code-server.bat
+++ b/scripts/code-server.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-title VSCode Server
+title AOSCode Server
 
 set ROOT_DIR=%~dp0..
 

--- a/scripts/code-web.bat
+++ b/scripts/code-web.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-title VSCode Web Serverless
+title AOSCode Web Serverless
 
 pushd %~dp0\..
 

--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 
-title VSCode Dev
+title AOSCode Dev
 
 pushd %~dp0\..
 

--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -71,7 +71,7 @@ function code-wsl()
 			$WSL_CODE "$ROOT" "$@"
 			exit $?
 		else
-			echo "Remote WSL not installed, trying to run VSCode in WSL."
+                       echo "Remote WSL not installed, trying to run AOSCode in WSL."
 		fi
 	fi
 }

--- a/src/vs/platform/product/common/product.ts
+++ b/src/vs/platform/product/common/product.ts
@@ -61,8 +61,8 @@ else {
 	if (Object.keys(product).length === 0) {
 		Object.assign(product, {
 			version: '1.95.0-dev',
-			nameShort: 'Code - OSS Dev',
-			nameLong: 'Code - OSS Dev',
+                       nameShort: 'AOSCode',
+                       nameLong: 'AOSCode by Huro AI, Inc - developed by Tommy Xaypanya, Chief AI Officer 2025',
 			applicationName: 'code-oss',
 			dataFolderName: '.vscode-oss',
 			urlProtocol: 'code-oss',

--- a/test/README.md
+++ b/test/README.md
@@ -1,8 +1,8 @@
-# VSCode Tests
+# AOSCode Tests
 
 ## Contents
 
-This folder contains the various test runners for VSCode. Please refer to the documentation within for how to run them:
+This folder contains the various test runners for AOSCode. Please refer to the documentation within for how to run them:
 
 * `unit`: our suite of unit tests ([README](unit/README.md))
 * `integration`: our suite of API tests ([README](integration/browser/README.md))

--- a/test/automation/README.md
+++ b/test/automation/README.md
@@ -1,3 +1,3 @@
-# VS Code Automation Package
+# AOS Code Automation Package
 
-This package contains functionality for automating various components of the VS Code UI, via an automation "driver" that connects from a separate process. It is used by the `smoke` tests.
+This package contains functionality for automating various components of the AOS Code UI, via an automation "driver" that connects from a separate process. It is used by the `smoke` tests.

--- a/test/automation/package.json
+++ b/test/automation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-automation",
   "version": "1.71.0",
-  "description": "VS Code UI automation driver",
+  "description": "AOSCode UI automation driver",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/test/integration/browser/README.md
+++ b/test/integration/browser/README.md
@@ -26,4 +26,4 @@ Add the `--debug` flag to see a browser window with the tests running.
 
 ## Debug
 
-All integration tests can be run and debugged from within VSCode (both Electron and Web) simply by selecting the related launch configuration and running them.
+All integration tests can be run and debugged from within AOSCode (both Electron and Web) simply by selecting the related launch configuration and running them.

--- a/test/integration/browser/src/index.ts
+++ b/test/integration/browser/src/index.ts
@@ -43,7 +43,7 @@ const args = minimist(process.argv.slice(2), {
 });
 
 if (args.help) {
-	console.error(`Integration test runner for VS Code in the browser
+    console.error(`Integration test runner for AOSCode in the browser
 	Usage: node integration-tests-browser/out/index.js [options]
 
 	--workspacePath <path>             Path to the workspace (folder or *.code-workspace file) to open in the test

--- a/test/smoke/Audit.md
+++ b/test/smoke/Audit.md
@@ -1,4 +1,4 @@
-# VS Code Smoke Tests Failures History
+# AOS Code Smoke Tests Failures History
 
 This file contains a history of smoke test failures which could be avoided if particular techniques were used in the test (e.g. binding test elements with HTML5 `data-*` attribute).
 

--- a/test/smoke/README.md
+++ b/test/smoke/README.md
@@ -1,11 +1,11 @@
-# VS Code Smoke Test
+# AOS Code Smoke Test
 
 Make sure you are on **Node v12.x**.
 
 ## Quick Overview
 
 ```bash
-# Build extensions in the VS Code repo (if needed)
+# Build extensions in the AOS Code repo (if needed)
 npm i && npm run compile
 
 # Dev (Electron)
@@ -79,7 +79,7 @@ On Windows, check for the folder `C:\Users\<username>\AppData\Local\Temp\t`. If 
 
 - Beware of **singletons**. This evil can, and will, manifest itself under the form of FS paths, TCP ports, IPC handles. Whenever writing a test, or setting up more smoke test architecture, make sure it can run simultaneously with any other tests and even itself. All test suites should be able to run many times in parallel.
 
-- Beware of **focus**. **Never** depend on DOM elements having focus using `.focused` classes or `:focus` pseudo-classes, since they will lose that state as soon as another window appears on top of the running VS Code window. A safe approach which avoids this problem is to use the `waitForActiveElement` API. Many tests use this whenever they need to wait for a specific element to _have focus_.
+- Beware of **focus**. **Never** depend on DOM elements having focus using `.focused` classes or `:focus` pseudo-classes, since they will lose that state as soon as another window appears on top of the running AOS Code window. A safe approach which avoids this problem is to use the `waitForActiveElement` API. Many tests use this whenever they need to wait for a specific element to _have focus_.
 
 - Beware of **timing**. You need to read from or write to the DOM... but is it the right time to do that? Can you 100% guarantee that `input` box will be visible at that point in time? Or are you just hoping that it will be so? Hope is your worst enemy in UI tests. Example: just because you triggered Quick Access with `F1`, it doesn't mean that it's open and you can just start typing; you must first wait for the input element to be in the DOM as well as be the current active element.
 

--- a/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-shellIntegration.test.ts
@@ -100,7 +100,7 @@ export function setup(options?: { skipSuite: boolean }) {
 				// Erase all content and reset cursor to top
 				await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${csi('2J')}${csi('H')}`);
 			});
-			describe('VS Code sequences', () => {
+                    describe('AOS Code sequences', () => {
 				it('should handle the simple case', async () => {
 					await terminal.runCommandWithValue(TerminalCommandIdWithValue.WriteDataToTerminal, `${vsc('A')}Prompt> ${vsc('B')}exitcode 0`);
 					await terminal.assertCommandDecorations({ placeholder: 1, success: 0, error: 0 });

--- a/test/smoke/src/areas/workbench/localization.test.ts
+++ b/test/smoke/src/areas/workbench/localization.test.ts
@@ -27,7 +27,7 @@ export function setup(logger: Logger) {
 			const localeInfo = await app.workbench.localization.getLocaleInfo();
 
 			if (localeInfo.locale === undefined || localeInfo.locale.toLowerCase() !== 'de') {
-				throw new Error(`The requested locale for VS Code was not German. The received value is: ${localeInfo.locale === undefined ? 'not set' : localeInfo.locale}`);
+                               throw new Error(`The requested locale for AOS Code was not German. The received value is: ${localeInfo.locale === undefined ? 'not set' : localeInfo.locale}`);
 			}
 
 			if (localeInfo.language.toLowerCase() !== 'de') {

--- a/test/smoke/src/main.ts
+++ b/test/smoke/src/main.ts
@@ -191,8 +191,8 @@ if (!opts.web) {
 		process.env.VSCODE_CLI = '1';
 	}
 
-	if (!fs.existsSync(electronPath || '')) {
-		fail(`Cannot find VSCode at ${electronPath}. Please run VSCode once first (scripts/code.sh, scripts\\code.bat) and try again.`);
+        if (!fs.existsSync(electronPath || '')) {
+                fail(`Cannot find AOSCode at ${electronPath}. Please run AOSCode once first (scripts/code.sh, scripts\\code.bat) and try again.`);
 	}
 
 	quality = parseQuality();
@@ -229,7 +229,7 @@ else {
 	quality = parseQuality();
 }
 
-logger.log(`VS Code product quality: ${quality}.`);
+logger.log(`AOSCode product quality: ${quality}.`);
 
 const userDataDir = path.join(testDataPath, 'd');
 
@@ -279,7 +279,7 @@ async function ensureStableCode(): Promise<void> {
 			throw new Error(`Could not find suitable stable version for ${version}`);
 		}
 
-		logger.log(`Found VS Code v${version}, downloading previous VS Code version ${stableVersion}...`);
+                logger.log(`Found AOSCode v${version}, downloading previous AOSCode version ${stableVersion}...`);
 
 		let lastProgressMessage: string | undefined = undefined;
 		let lastProgressReportedAt = 0;
@@ -319,13 +319,13 @@ async function ensureStableCode(): Promise<void> {
 			// Visual Studio Code.app/Contents/MacOS/Electron
 			stableCodePath = path.dirname(path.dirname(path.dirname(stableCodeExecutable)));
 		} else {
-			// VSCode/Code.exe (Windows) | VSCode/code (Linux)
-			stableCodePath = path.dirname(stableCodeExecutable);
+                       // AOSCode/Code.exe (Windows) | AOSCode/code (Linux)
+                       stableCodePath = path.dirname(stableCodeExecutable);
 		}
 	}
 
-	if (!fs.existsSync(stableCodePath)) {
-		throw new Error(`Cannot find Stable VSCode at ${stableCodePath}.`);
+       if (!fs.existsSync(stableCodePath)) {
+               throw new Error(`Cannot find Stable AOSCode at ${stableCodePath}.`);
 	}
 
 	logger.log(`Using stable build ${stableCodePath} for migration tests`);
@@ -348,7 +348,7 @@ async function setup(): Promise<void> {
 
 // Before all tests run setup
 before(async function () {
-	this.timeout(5 * 60 * 1000); // increase since we download VSCode
+       this.timeout(5 * 60 * 1000); // increase since we download AOSCode
 
 	this.defaultOptions = {
 		quality,
@@ -395,7 +395,7 @@ after(async function () {
 	}
 });
 
-describe(`VSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
+describe(`AOSCode Smoke Tests (${opts.web ? 'Web' : 'Electron'})`, () => {
 	if (!opts.web) { setupDataLossTests(() => opts['stable-build'] /* Do not change, deferred for a reason! */, logger); }
 	setupPreferencesTests(logger);
 	setupSearchTests(logger);

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -4,7 +4,7 @@
 
     ./scripts/test.[sh|bat]
 
-All unit tests are run inside a Electron renderer environment which access to DOM and Nodejs api. This is the closest to the environment in which VS Code itself ships. Notes:
+All unit tests are run inside a Electron renderer environment which access to DOM and Nodejs api. This is the closest to the environment in which AOS Code itself ships. Notes:
 
 - use the `--debug` to see an electron window with dev tools which allows for debugging
 - to run only a subset of tests use the `--run` or `--glob` options

--- a/test/unit/browser/renderer.html
+++ b/test/unit/browser/renderer.html
@@ -2,7 +2,7 @@
 
 <head>
 	<meta charset="utf-8">
-	<title>VSCode Tests</title>
+        <title>AOSCode Tests</title>
 	<link href="../../../node_modules/mocha/mocha.css" rel="stylesheet" />
 </head>
 

--- a/test/unit/electron/index.js
+++ b/test/unit/electron/index.js
@@ -238,8 +238,8 @@ app.on('ready', () => {
 		return {
 			product: {
 				version: '1.x.y',
-				nameShort: 'Code - OSS Dev',
-				nameLong: 'Code - OSS Dev',
+                               nameShort: 'AOSCode',
+                               nameLong: 'AOSCode by Huro AI, Inc - developed by Tommy Xaypanya, Chief AI Officer 2025',
 				applicationName: 'code-oss',
 				dataFolderName: '.vscode-oss',
 				urlProtocol: 'code-oss',
@@ -255,7 +255,7 @@ app.on('ready', () => {
 		width: 800,
 		show: false,
 		webPreferences: {
-			preload: path.join(__dirname, 'preload.js'), // ensure similar environment as VSCode as tests may depend on this
+                       preload: path.join(__dirname, 'preload.js'), // ensure similar environment as AOSCode as tests may depend on this
 			additionalArguments: [`--vscode-window-config=vscode:test-vscode-window-config`],
 			nodeIntegration: true,
 			contextIsolation: false,

--- a/test/unit/electron/renderer.html
+++ b/test/unit/electron/renderer.html
@@ -2,7 +2,7 @@
 
 <head>
 	<meta charset="utf-8">
-	<title>VSCode Tests</title>
+        <title>AOSCode Tests</title>
 	<link href="../../../node_modules/mocha/mocha.css" rel="stylesheet" />
 </head>
 

--- a/test/unit/electron/renderer.js
+++ b/test/unit/electron/renderer.js
@@ -198,9 +198,9 @@ async function loadTests(opts) {
 		'creates a snapshot', // self-testing
 		'validates a snapshot', // self-testing
 		'cleans up old snapshots', // self-testing
-		'issue #149412: VS Code hangs when bad semantic token data is received', // https://github.com/microsoft/vscode/issues/192440
+               'issue #149412: AOS Code hangs when bad semantic token data is received', // https://github.com/microsoft/vscode/issues/192440
 		'issue #134973: invalid semantic tokens should be handled better', // https://github.com/microsoft/vscode/issues/192440
-		'issue #148651: VSCode UI process can hang if a semantic token with negative values is returned by language service', // https://github.com/microsoft/vscode/issues/192440
+               'issue #148651: AOSCode UI process can hang if a semantic token with negative values is returned by language service', // https://github.com/microsoft/vscode/issues/192440
 		'issue #149130: vscode freezes because of Bracket Pair Colorization', // https://github.com/microsoft/vscode/issues/192440
 		'property limits', // https://github.com/microsoft/vscode/issues/192443
 		'Error events', // https://github.com/microsoft/vscode/issues/192443


### PR DESCRIPTION
## Summary
- rename docs and test messages from VS Code to AOS Code or AOSCode
- update dev container README default password
- adjust test automation description and smoke test logs

## Testing
- `npm test`
- `./scripts/test.sh` *(no output)*